### PR TITLE
firmware loader: add writable search path for use with android

### DIFF
--- a/drivers/base/firmware_class.c
+++ b/drivers/base/firmware_class.c
@@ -292,7 +292,8 @@ static const char * const fw_path[] = {
 	"/lib/firmware/updates/" UTS_RELEASE,
 	"/lib/firmware/updates",
 	"/lib/firmware/" UTS_RELEASE,
-	"/lib/firmware"
+	"/lib/firmware",
+	"/system/lib/firmware"
 };
 
 /*


### PR DESCRIPTION
This change might not be required long term, if the .raw file can be added to one of the other paths.  This was path of least resistance to get it where it was easy to write to from a booted system.