### PR TITLE
Disabled ngx like safe shutdown on battery disconnect as it is not ap…

### DIFF
--- a/arch/arm/boot/dts/qcom/apq8016-var-sd410.dtsi
+++ b/arch/arm/boot/dts/qcom/apq8016-var-sd410.dtsi
@@ -122,7 +122,7 @@
 			sciaps,voltage-charge-low-thres-uV = <13500000>;
 			//sciaps,gpio-charge-in-progress = <&msm_gpio 62 0>;
 			//sciaps,gpio-charge-completed = <&msm_gpio 21 0>;
-			sciaps,support-shutdown = <1>;
+			sciaps,support-shutdown = <0>;
 			sciaps,shutdown-timer	= <30>;
 
 			status = "ok";


### PR DESCRIPTION
…plicable for ngl. It causes boot loop if there's no comms with the battery!