### PR TITLE
IE Battery: Hot swap & false battery presence 

### DIFF
--- a/drivers/mfd/sciaps_micro.c
+++ b/drivers/mfd/sciaps_micro.c
@@ -634,7 +634,7 @@ int sciaps_micro_read_register(uint8_t reg, uint16_t *value_out)
 		pr_err("%s: error reading from i2c bus: 0x%x", __func__, err);
 	}
 	else {
-		pr_info("%s: Register 0x%x is 0x%x\n", __func__, reg, value);
+		pr_debug("%s: Register 0x%x is 0x%x\n", __func__, reg, value);
 		if (value_out)
 		   *value_out = value;
 	}

--- a/drivers/power/smb-ti-bq40z80-battery.c
+++ b/drivers/power/smb-ti-bq40z80-battery.c
@@ -864,6 +864,11 @@ void deactivate_ti_bq40z80(void)
 	}
 }
 
+#define NO_BATTERY_COUNT_LIMIT			200
+#define NO_BATTERY_RESET_COUNT_LIMIT	2
+
+static uint8_t s_no_battery_count = 0;
+static  int8_t s_no_battery_reset_count = NO_BATTERY_RESET_COUNT_LIMIT;
 
 static void smb_ti_bq40z80_delayed_work(struct work_struct *work)
 {
@@ -967,7 +972,29 @@ static void smb_ti_bq40z80_delayed_work(struct work_struct *work)
 			}
 		}
 		else {
-			no_battery = true;
+			int battery_presence = sciaps_micro_check_battery_presence();
+			no_battery = false;
+			if (battery_presence != 0) {
+				if (s_no_battery_count < NO_BATTERY_COUNT_LIMIT)
+					s_no_battery_count++;
+				s_no_battery_reset_count = NO_BATTERY_RESET_COUNT_LIMIT;
+				no_battery = true;
+			}
+			else {
+				// Check again
+				if (s_no_battery_count > 0 ) {
+					if (s_no_battery_reset_count > 0) {
+						if (s_no_battery_count < NO_BATTERY_COUNT_LIMIT)
+							s_no_battery_count++;
+						s_no_battery_reset_count--;
+						no_battery = true;
+					}
+					else {
+						s_no_battery_count = 0;
+						s_no_battery_reset_count = NO_BATTERY_RESET_COUNT_LIMIT;
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
IE Battery only: Hot swap detection based on PIC register and workaround for intermittent false battery presence reporting from PIC