### PR TITLE
BTX macro camera auto-focus, device tree, and BTX board hardware id. NGX DPP mux select 96 & 108 initialization

### DIFF
--- a/arch/arm/boot/dts/qcom/Makefile
+++ b/arch/arm/boot/dts/qcom/Makefile
@@ -68,6 +68,8 @@ dtb-$(CONFIG_ARCH_MSM8916) += apq8016-var-sd410-sciaps-ngx-ampteck-dpp2.dtb \
 	apq8016-var-sd410-sciaps-ngx-ampteck-dpp2-no-wcnss.dtb \
 	apq8016-var-sd410-sciaps-ngx-dpp3.dtb \
 	apq8016-var-sd410-sciaps-ngx-dpp3-no-wcnss.dtb \
+	apq8016-var-sd410-sciaps-btx.dtb \
+	apq8016-var-sd410-sciaps-btx-no-wcnss.dtb \
 	apq8016-var-sd410-sciaps-ngl.dtb \
 	apq8016-var-sd410-sciaps-ngl-no-wcnss.dtb
 dtb-$(CONFIG_ARCH_MSM8226) += msm8226-sim.dtb \

--- a/arch/arm/boot/dts/qcom/apq8016-camera-sensor-var-sd410-sciaps-btx.dtsi
+++ b/arch/arm/boot/dts/qcom/apq8016-camera-sensor-var-sd410-sciaps-btx.dtsi
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+&soc {
+};
+
+&cci {
+	qcom,camera@74 {
+		compatible = "ovti,ov56450";
+		reg = <0x74 0x0>;
+		qcom,slave-id = <0x74 0x300a 0x5645>;
+		qcom,slave-id-ex = <0x78 0x3100 0x0000>;
+		qcom,csiphy-sd-index = <0>;
+		qcom,csid-sd-index = <0>;
+		qcom,mount-angle = <90>;
+		qcom,sensor-name = "ov56450";
+		cam_vdig-supply = <&vph_pwr_vreg>;
+		cam_vana-supply = <&vph_pwr_vreg>;
+		cam_vio-supply = <&vph_pwr_vreg>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana";
+		qcom,cam-vreg-min-voltage = <2100000 0 2850000>;
+		qcom,cam-vreg-max-voltage = <2100000 0 2850000>;
+		qcom,cam-vreg-op-mode = <200000 0 80000>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk0_default &cam_sensor_rear_default>;
+		pinctrl-1 = <&cam_sensor_mclk0_sleep &cam_sensor_rear_sleep>;
+		gpios = <&msm_gpio 26 0>,
+			<&msm_gpio 97 0>,
+			<&msm_gpio 34 0>;
+		qcom,gpio-reset = <1>;
+		qcom,gpio-standby = <2>;
+		qcom,gpio-req-tbl-num = <0 1 2>;
+		qcom,gpio-req-tbl-flags = <1 0 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK",
+			"CAM_RESET",
+			"CAM_STANDBY";
+		qcom,gpio-set-tbl-num = <1 1>;
+		qcom,gpio-set-tbl-flags = <0 2>;
+		qcom,gpio-set-tbl-delay = <1000 4000>;
+		qcom,csi-lane-assign = <0x4320>;
+		qcom,csi-lane-mask = <0x3>;
+		qcom,sensor-position = <0>;
+		qcom,sensor-mode = <0>;
+		qcom,cci-master = <0>;
+		qcom,mclk-23880000;
+		clocks = <&clock_gcc clk_mclk0_clk_src>,
+				<&clock_gcc clk_gcc_camss_mclk0_clk>;
+		clock-names = "cam_src_clk", "cam_clk";
+	};
+
+	qcom,camera@76 {
+		compatible = "ovti,ov5645";
+		reg = <0x76 0x0>;
+		qcom,slave-id = <0x76 0x300a 0x5645>;
+		qcom,slave-id-ex = <0x78 0x3100 0x0001>;
+		qcom,csiphy-sd-index = <1>;
+		qcom,csid-sd-index = <1>;
+		qcom,mount-angle = <90>;
+		qcom,sensor-name = "ov5645";
+		cam_vdig-supply = <&vph_pwr_vreg>;
+		cam_vana-supply = <&vph_pwr_vreg>;
+		cam_vio-supply = <&vph_pwr_vreg>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana";
+		qcom,cam-vreg-min-voltage = <2100000 0 2850000>;
+		qcom,cam-vreg-max-voltage = <2100000 0 2850000>;
+		qcom,cam-vreg-op-mode = <200000 0 80000>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk1_default &cam_sensor_front_default>;
+		pinctrl-1 = <&cam_sensor_mclk1_sleep &cam_sensor_front_sleep>;
+		gpios = <&msm_gpio 27 0>,
+			<&msm_gpio 28 0>,
+			<&msm_gpio 33 0>;
+		qcom,gpio-reset = <1>;
+		qcom,gpio-standby = <2>;
+		qcom,gpio-req-tbl-num = <0 1 2>;
+		qcom,gpio-req-tbl-flags = <1 0 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK",
+			"CAM_RESET",
+			"CAM_STANDBY";
+		qcom,gpio-set-tbl-num = <1 1>;
+		qcom,gpio-set-tbl-flags = <0 2>;
+		qcom,gpio-set-tbl-delay = <1000 4000>;
+		qcom,csi-lane-assign = <0x4320>;
+		qcom,csi-lane-mask = <0x3>;
+		qcom,sensor-position = <1>;
+		qcom,sensor-mode = <0>;
+		qcom,cci-master = <0>;
+		qcom,mclk-23880000;
+		clocks = <&clock_gcc clk_mclk1_clk_src>,
+				<&clock_gcc clk_gcc_camss_mclk1_clk>;
+		clock-names = "cam_src_clk", "cam_clk";
+	};
+
+	qcom,camera@0 {
+		cell-index = <0>;
+		compatible = "qcom,camera";
+		reg = <0x0>;
+		qcom,csiphy-sd-index = <0>;
+		qcom,csid-sd-index = <0>;
+		qcom,mount-angle = <90>;
+		cam_vdig-supply = <&vph_pwr_vreg>;
+		cam_vana-supply = <&vph_pwr_vreg>;
+		cam_vio-supply = <&vph_pwr_vreg>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana";
+		qcom,cam-vreg-min-voltage = <2100000 0 2850000>;
+		qcom,cam-vreg-max-voltage = <2100000 0 2850000>;
+		qcom,cam-vreg-op-mode = <200000 0 80000>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk0_default &cam_sensor_rear_default>;
+		pinctrl-1 = <&cam_sensor_mclk0_sleep &cam_sensor_rear_sleep>;
+		gpios = <&msm_gpio 26 0>,
+			<&msm_gpio 97 0>,
+			<&msm_gpio 34 0>;
+		qcom,gpio-reset = <1>;
+		qcom,gpio-standby = <2>;
+		qcom,gpio-req-tbl-num = <0 1 2>;
+		qcom,gpio-req-tbl-flags = <1 0 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK",
+			"CAM_RESET",
+			"CAM_STANDBY";
+		qcom,cci-master = <0>;
+		qcom,mclk-23880000;
+		status = "ok";
+		clocks = <&clock_gcc clk_mclk0_clk_src>,
+				<&clock_gcc clk_gcc_camss_mclk0_clk>;
+		clock-names = "cam_src_clk", "cam_clk";
+	};
+
+	qcom,camera@1 {
+		cell-index = <1>;
+		compatible = "qcom,camera";
+		reg = <0x1>;
+		qcom,csiphy-sd-index = <1>;
+		qcom,csid-sd-index = <1>;
+		qcom,mount-angle = <90>;
+		cam_vdig-supply = <&vph_pwr_vreg>;
+		cam_vana-supply = <&vph_pwr_vreg>;
+		cam_vio-supply = <&vph_pwr_vreg>;
+		qcom,cam-vreg-name = "cam_vdig", "cam_vio", "cam_vana";
+		qcom,cam-vreg-min-voltage = <2100000 0 2850000>;
+		qcom,cam-vreg-max-voltage = <2100000 0 2850000>;
+		qcom,cam-vreg-op-mode = <200000 0 80000>;
+		pinctrl-names = "cam_default", "cam_suspend";
+		pinctrl-0 = <&cam_sensor_mclk1_default &cam_sensor_front_default>;
+		pinctrl-1 = <&cam_sensor_mclk1_sleep &cam_sensor_front_sleep>;
+		gpios = <&msm_gpio 27 0>,
+			<&msm_gpio 28 0>,
+			<&msm_gpio 33 0>;
+		qcom,gpio-reset = <1>;
+		qcom,gpio-standby = <2>;
+		qcom,gpio-req-tbl-num = <0 1 2>;
+		qcom,gpio-req-tbl-flags = <1 0 0>;
+		qcom,gpio-req-tbl-label = "CAMIF_MCLK",
+			"CAM_RESET",
+			"CAM_STANDBY";
+		qcom,cci-master = <0>;
+		qcom,mclk-23880000;
+		status = "ok";
+		clocks = <&clock_gcc clk_mclk1_clk_src>,
+				<&clock_gcc clk_gcc_camss_mclk1_clk>;
+		clock-names = "cam_src_clk", "cam_clk";
+	};
+};

--- a/arch/arm/boot/dts/qcom/apq8016-var-sd410-sciaps-btx-no-wcnss.dts
+++ b/arch/arm/boot/dts/qcom/apq8016-var-sd410-sciaps-btx-no-wcnss.dts
@@ -1,0 +1,25 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License version 2 and
+* only version 2 as published by the Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
+/dts-v1/;
+
+#include "apq8016.dtsi"
+#include "apq8016-var-sd410-sciaps-btx.dtsi"
+#include "apq8016-var-sd410-sciaps-disable-wcnss.dtsi"
+
+
+/ {
+	model = "SciAps BTX - SOM: Variscite DART-SD410 - WCNSS Disabled";
+	compatible = "qcom,apq8016";
+	qcom,msm-id = <247 0>;
+	qcom,board-id = <37 0>;
+};

--- a/arch/arm/boot/dts/qcom/apq8016-var-sd410-sciaps-btx.dts
+++ b/arch/arm/boot/dts/qcom/apq8016-var-sd410-sciaps-btx.dts
@@ -1,0 +1,24 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License version 2 and
+* only version 2 as published by the Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
+/dts-v1/;
+
+#include "apq8016.dtsi"
+#include "apq8016-var-sd410-sciaps-btx.dtsi"
+
+
+/ {
+	model = "SciAps BTX - SOM: Variscite DART-SD410";
+	compatible = "qcom,apq8016";
+	qcom,msm-id = <247 0>;
+	qcom,board-id = <32 0>;
+};

--- a/arch/arm/boot/dts/qcom/apq8016-var-sd410-sciaps-btx.dtsi
+++ b/arch/arm/boot/dts/qcom/apq8016-var-sd410-sciaps-btx.dtsi
@@ -1,0 +1,66 @@
+/* Copyright (c) 2015, The Linux Foundation. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "apq8016-var-sd410-sciaps-ngx-ampteck-dpp2.dtsi"
+#include "apq8016-camera-sensor-var-sd410-sciaps-btx.dtsi"
+
+&cci {
+
+	actuator0: qcom,actuator@0 {
+		status = "disabled";
+	};
+
+	eeprom0: qcom,eeprom@20 {
+		status = "disabled";
+	};
+
+	qcom,camera@42 {
+		status = "disabled";
+	};
+};
+
+&soc {
+	i2c@78b8000 { /* BLSP1 QUP4 */
+        ie-battery@b {
+			//status = "okay";
+            status = "disabled";
+		};
+        ie-charger@9 {
+			//status = "okay";
+            status = "disabled";
+		};
+		battery@0x64 {
+			//status = "okay";
+            status = "disabled";
+		};
+        ie-nh3054hd34-battery@b {
+            compatible = "nh2054";
+            reg = <0xb>;
+            //sciaps,support-shutdown = <1>;
+            //sciaps,shutdown-timer   = <25>;
+            //sciaps,capacity-low-thres-mAh = <10>;
+            //sciaps,capacity-low-thres = <5>; // 0.5 %
+            //sciaps,voltage-crit-low-thres-mV = <11000>;
+            //sciaps,voltage-low-thres-mV = <14000>;
+            //status = "disabled";
+			status = "okay";
+        };
+
+        ie-charger@9 {
+            compatible = "ltc1760";
+            reg = <0xa>;
+            //status = "disabled";
+			status = "okay";
+        };
+	};
+};
+

--- a/arch/arm/boot/dts/qcom/apq8016-var-sd410-sciaps-ngl.dtsi
+++ b/arch/arm/boot/dts/qcom/apq8016-var-sd410-sciaps-ngl.dtsi
@@ -26,6 +26,16 @@
 			sciaps,support-shutdown = <0>;
 			status = "ok";
 		};
+
+		i2c@78b8000 { /* BLSP1 QUP4 */
+			status = "ok";
+
+			sciaps_micro@59 {
+				compatible = "sciaps_micro";
+				reg = <0x59>;
+				status = "ok";
+			};
+		};
 	};
 
 };

--- a/arch/arm/boot/dts/qcom/apq8016-var-sd410-sciaps-ngx.dtsi
+++ b/arch/arm/boot/dts/qcom/apq8016-var-sd410-sciaps-ngx.dtsi
@@ -30,6 +30,20 @@
 		};
 	};
 
+	i2c@78b8000 { /* BLSP1 QUP4 */
+        status = "ok";
+
+		sciaps_micro@59 {
+			compatible = "sciaps_micro";
+			pinctrl-names = "dpp_mux_select_active";
+			pinctrl-0 = <&gpio_dpp_mux_select_active &gpio_dpp_mux_select_legacy_active>;
+			sciaps,dpp-mux-select			= <&msm_gpio 108 0>;
+			sciaps,dpp-mux-select-legacy	= <&msm_gpio 96 0>;
+			reg = <0x59>;
+			status = "ok";
+		};
+	};
+
 	i2c@78ba000 { /* BLSP1 QUP6 */
 		status = "ok";
 		focaltech@38{

--- a/arch/arm/boot/dts/qcom/msm8916-pinctrl.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8916-pinctrl.dtsi
@@ -1191,9 +1191,9 @@
 		};
 
 		tlmm_gpio_key {
-			qcom,pins = <&gp 107>, <&gp 108>, <&gp 109>;
+			qcom,pins = <&gp 107>, <&gp 109>;
 			qcom,pin-func = <0>;
-			qcom,num-grp-pins = <3>;
+			qcom,num-grp-pins = <2>;
 			label = "tlmm_gpio_key";
 			gpio_key_active: gpio_key_active {
 				drive-strength = <2>;
@@ -1202,6 +1202,32 @@
 			gpio_key_suspend: gpio_key_suspend {
 				drive-strength = <2>;
 				bias-pull-up;
+			};
+		};
+
+		gpio_dpp_mux_select_pins {
+			qcom,pins = <&gp 108>;
+			qcom,pin-func = <0>;
+			qcom,num-grp-pins = <1>;
+			label = "gpio-mux-select-pins";
+			gpio_dpp_mux_select_active: gpio_dpp_mux_select_active {
+				drive-strength = <16>; /* 16 mA */
+				bias-pull-down; /* pull down */
+				input-enable;
+				//output-high;
+			};
+		};
+
+		gpio_dpp_mux_select_legacy_pins {
+			qcom,pins = <&gp 96>;
+			qcom,pin-func = <0>;
+			qcom,num-grp-pins = <1>;
+			label = "gpio-mux-select-legacy-pins";
+			gpio_dpp_mux_select_legacy_active: gpio_dpp_mux_select_legacy_active {
+				drive-strength = <16>; /* 16 mA */
+				bias-pull-down; /* pull down */
+				input-enable;
+				//output-high;
 			};
 		};
 

--- a/drivers/mfd/sciaps_micro.c
+++ b/drivers/mfd/sciaps_micro.c
@@ -7,18 +7,41 @@
 #include <linux/sysfs.h>
 #include <linux/mod_devicetable.h>
 #include <linux/of.h>
+#include <linux/of_device.h>
+#include <linux/of_gpio.h>
 #include <linux/i2c.h>
 #include <linux/types.h>
+#include <linux/pinctrl/consumer.h>
 
 #include <linux/qpnp/power-on.h>
 
 #include <linux/mfd/sciaps_micro.h>
 
+#define SCIAPS_CARRIER_BOARD_HW_REV_10_PLUS_BLUE		10
+#define SCIAPS_CARRIER_BOARD_HW_REV_PRIOR_REV_10_RED	6
+#define SCIAPS_CARRIER_BOARD_HW_REV_UNKNOWN				0
+
+#define SCIAPS_DPP_MUX_SELECT_WORK 0
+#if SCIAPS_DPP_MUX_SELECT_WORK
+#error SCIAPS_DPP_MUX_SELECT_WORK MUST be disabled in this version!!!
+#endif
+
+const char* dpp_mux_select_dt_name = "sciaps,dpp-mux-select";
+const char* dpp_mux_select_legacy_dt_name = "sciaps,dpp-mux-select-legacy";
 
 struct sciaps_micro_data {
 	struct	i2c_client	*client;
 	u8 read_reg;
 	u16 read_reg_value;
+	int dpp_mux_select_gpio_pin_value;
+	int dpp_mux_select_gpio_pin;
+	bool dpp_mux_select_gpio_pin_free;
+	int dpp_mux_select_legacy_gpio_pin;
+	bool dpp_mux_select_legacy_gpio_pin_free;
+	int carrier_board_hw_rev;
+#if SCIAPS_DPP_MUX_SELECT_WORK
+	struct delayed_work	work;
+#endif
 	bool			nvram_unlocked;
 };
 
@@ -34,6 +57,24 @@ static sciaps_micro_cmds sciaps_micro_known_cmds[] = {
 };
 
 static const int libs_cmd_num = sizeof(sciaps_micro_known_cmds)/sizeof(sciaps_micro_cmds);
+
+#if SCIAPS_DPP_MUX_SELECT_WORK
+static void dpp_mux_select_legacy_delayed_work(struct work_struct *work)
+{
+	struct  sciaps_micro_data *data;
+
+	data = container_of(work, struct sciaps_micro_data, work.work);
+
+	if (data->dpp_mux_select_legacy_gpio_pin_free && data->carrier_board_hw_rev == SCIAPS_CARRIER_BOARD_HW_REV_PRIOR_REV_10_RED) {
+		if (data->dpp_mux_select_gpio_pin_value != gpio_get_value(data->dpp_mux_select_legacy_gpio_pin)) {
+			dev_info(&data->client->dev, "%s-%d: Oops... Legacy MUX Select level changed unexpectedly! Setting it back to %d via GPIO_%d(%s)\n", __func__, HZ, data->dpp_mux_select_gpio_pin_value, data->dpp_mux_select_legacy_gpio_pin, dpp_mux_select_legacy_dt_name);
+			gpio_set_value(data->dpp_mux_select_legacy_gpio_pin, data->dpp_mux_select_gpio_pin_value);
+		}
+
+		schedule_delayed_work(&data->work, 10/*1*HZ*/);
+	}
+}
+#endif
 
 #if 0
 static int sciaps_micro_i2c_read(struct i2c_client *client, int count,
@@ -520,10 +561,35 @@ trigger_gpio_fail:
 
 static struct i2c_client *sciaps_micro_i2c_client = NULL;
 
+#define SCIAPS_DPP_MUX_SELECT_PIN_GPIO			(108 + 902)
+#define SCIAPS_DPP_MUX_SELECT_LEGACY_PIN_GPIO	(96 + 902)
+
+#define PINCTRL_SCIAPS_DPP_MUX_SELECT_ACTIVE "dpp_mux_select_active"
+
 static int sciaps_micro_probe(struct i2c_client *client,
 			const struct i2c_device_id *id)
 {
 	struct sciaps_micro_data *sciaps_micro;
+	struct pinctrl *pinctrl;
+	struct pinctrl_state *set_state;
+	struct device *dev = &client->dev;
+
+
+
+	/* Get pinctrl if target uses pinctrl */
+	pinctrl = devm_pinctrl_get(dev);
+	if (IS_ERR(pinctrl)) {
+		if (PTR_ERR(pinctrl) == -EPROBE_DEFER) {
+			dev_warn(dev, "%s: devm_pinctrl_get rc: %ld(EPROBE_DEFER)\n", __func__, PTR_ERR(pinctrl));
+			return -EPROBE_DEFER;
+		}
+
+		dev_warn(dev, "%s: devm_pinctrl_get rc: %ld\n", __func__, PTR_ERR(pinctrl));
+		pinctrl = NULL;
+	}
+	else {
+		dev_info(dev, "%s: devm_pinctrl_get SUCCESS\n", __func__);
+	}
 
 	sciaps_micro = kzalloc(sizeof(struct sciaps_micro_data), GFP_KERNEL);
 	if (!sciaps_micro) {
@@ -535,6 +601,123 @@ static int sciaps_micro_probe(struct i2c_client *client,
 	sciaps_micro->read_reg = 0;
 	sciaps_micro->read_reg_value = 0;
 	sciaps_micro->nvram_unlocked = 0;
+	sciaps_micro->dpp_mux_select_gpio_pin = -1; //SCIAPS_DPP_MUX_SELECT_PIN_GPIO;
+	sciaps_micro->dpp_mux_select_gpio_pin_free = false;
+	sciaps_micro->dpp_mux_select_legacy_gpio_pin = -1; //SCIAPS_DPP_MUX_SELECT_LEGACY_PIN_GPIO;
+	sciaps_micro->dpp_mux_select_legacy_gpio_pin_free = false;
+	sciaps_micro->carrier_board_hw_rev = SCIAPS_CARRIER_BOARD_HW_REV_UNKNOWN;
+	sciaps_micro->dpp_mux_select_gpio_pin_value = 1;
+
+#if SCIAPS_DPP_MUX_SELECT_WORK
+	INIT_DELAYED_WORK(&sciaps_micro->work, dpp_mux_select_legacy_delayed_work);
+#endif
+
+	{
+		struct device_node *np = of_node_get(client->dev.of_node);
+		int dpp_mux_select = -1;
+
+		if (np) {
+			dpp_mux_select = -1;
+			if (1 == of_gpio_named_count(np, dpp_mux_select_dt_name)) {
+				if (pinctrl) {
+					set_state = pinctrl_lookup_state(pinctrl, PINCTRL_SCIAPS_DPP_MUX_SELECT_ACTIVE);
+					if (IS_ERR(set_state)) {
+						dev_err(dev, "%s: pinctrl_lookup_state rc: %ld for %s\n", __func__, PTR_ERR(pinctrl), PINCTRL_SCIAPS_DPP_MUX_SELECT_ACTIVE);
+						//return PTR_ERR(set_state);
+					}
+					else {
+						int retval;
+						dev_info(dev, "%s: pinctrl_lookup_state for %s SUCCESS\n", __func__, PINCTRL_SCIAPS_DPP_MUX_SELECT_ACTIVE);
+						retval = pinctrl_select_state(pinctrl, set_state);
+						if (retval) {
+							dev_err(dev,"%s: cannot set ts pinctrl state for %s rc: %d\n", __func__, PINCTRL_SCIAPS_DPP_MUX_SELECT_ACTIVE, retval);
+						}
+						else {
+							dev_info(dev, "%s: pinctrl_select_state for %s SUCCESS\n", __func__, PINCTRL_SCIAPS_DPP_MUX_SELECT_ACTIVE);
+							pinctrl = NULL;
+						}
+					}
+				}
+
+				dpp_mux_select  = of_get_named_gpio(np, dpp_mux_select_dt_name, 0);
+
+				dev_info(&client->dev,
+						"%s :  %s is %d\n", __func__, dpp_mux_select_dt_name, dpp_mux_select);
+
+				if (gpio_is_valid(dpp_mux_select)) {
+					dev_info(&client->dev,
+							"%s : %s gpio is valid\n", __func__, dpp_mux_select_dt_name);
+				}
+				else {
+					dpp_mux_select = SCIAPS_DPP_MUX_SELECT_PIN_GPIO;
+					dev_warn(&client->dev,
+							"%s : %s gpio is NOT valid. Using default: %d\n", __func__, dpp_mux_select_dt_name, dpp_mux_select);
+				}
+			}
+			else {
+				dev_warn(&client->dev,
+						"%s : Could not find %s in the devicetree. Do nothing!\n", __func__, dpp_mux_select_dt_name);
+			}
+			if (dpp_mux_select != -1)
+				sciaps_micro->dpp_mux_select_gpio_pin = dpp_mux_select;
+
+			dpp_mux_select = -1;
+			if (1 == of_gpio_named_count(np, dpp_mux_select_legacy_dt_name)) {
+				if (pinctrl) {
+					set_state = pinctrl_lookup_state(pinctrl, PINCTRL_SCIAPS_DPP_MUX_SELECT_ACTIVE);
+					if (IS_ERR(set_state)) {
+						dev_err(dev, "%s: pinctrl_lookup_state rc: %ld for %s\n", __func__, PTR_ERR(pinctrl), PINCTRL_SCIAPS_DPP_MUX_SELECT_ACTIVE);
+						//return PTR_ERR(set_state);
+					}
+					else {
+						int retval;
+						dev_info(dev, "%s: pinctrl_lookup_state for %s SUCCESS\n", __func__, PINCTRL_SCIAPS_DPP_MUX_SELECT_ACTIVE);
+						retval = pinctrl_select_state(pinctrl, set_state);
+						if (retval) {
+							dev_err(dev,"%s: cannot set ts pinctrl state for %s rc: %d\n", __func__, PINCTRL_SCIAPS_DPP_MUX_SELECT_ACTIVE, retval);
+						}
+						else {
+							dev_info(dev, "%s: pinctrl_select_state for %s SUCCESS\n", __func__, PINCTRL_SCIAPS_DPP_MUX_SELECT_ACTIVE);
+							pinctrl = NULL;
+						}
+					}
+				}
+
+				dpp_mux_select  = of_get_named_gpio(np, dpp_mux_select_legacy_dt_name, 0);
+
+				dev_info(&client->dev,
+						"%s :  %s is %d\n", __func__, dpp_mux_select_legacy_dt_name, dpp_mux_select);
+
+				if (gpio_is_valid(dpp_mux_select)) {
+					dev_info(&client->dev,
+							"%s : %s gpio is valid\n", __func__, dpp_mux_select_legacy_dt_name);
+				}
+				else {
+					dpp_mux_select = SCIAPS_DPP_MUX_SELECT_LEGACY_PIN_GPIO;
+					dev_warn(&client->dev,
+							"%s : %s gpio is NOT valid. Using default: %d\n", __func__, dpp_mux_select_legacy_dt_name, dpp_mux_select);
+				}
+			}
+			else {
+				dev_warn(&client->dev,
+						"%s : Could not find %s in the devicetree. Do nothing!\n", __func__, dpp_mux_select_legacy_dt_name);
+			}
+			if (dpp_mux_select != -1) {
+				sciaps_micro->dpp_mux_select_legacy_gpio_pin = dpp_mux_select;
+				if (sciaps_micro->dpp_mux_select_gpio_pin == -1) {
+					sciaps_micro->dpp_mux_select_gpio_pin = SCIAPS_DPP_MUX_SELECT_PIN_GPIO;
+					dev_warn(&client->dev,
+							"%s : %s gpio is NOT set. Using default: %d\n", __func__, dpp_mux_select_dt_name, sciaps_micro->dpp_mux_select_gpio_pin);
+
+				}
+			}
+
+		}
+		else {
+			dev_warn(&client->dev,
+					"%s : Could not retrive of_node. Do nothing for %s and %s\n", __func__, dpp_mux_select_dt_name, dpp_mux_select_legacy_dt_name);
+		}
+	}
 
 	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C)) {
 		dev_err(&client->dev, "i2c not supported\n");
@@ -549,6 +732,67 @@ static int sciaps_micro_probe(struct i2c_client *client,
 
 	trigger_gpio_init(client);
 
+	if (sciaps_micro->dpp_mux_select_gpio_pin != -1 && sciaps_micro->dpp_mux_select_legacy_gpio_pin != -1) {
+		int rc;
+		rc = gpio_request(sciaps_micro->dpp_mux_select_gpio_pin, dpp_mux_select_dt_name);
+		if (rc) {
+			dev_err(&client->dev, "%s: gpio %d(%s) request failed with err: %d\n",
+					__func__, sciaps_micro->dpp_mux_select_gpio_pin, dpp_mux_select_dt_name,  rc);
+		}
+		else {
+			sciaps_micro->dpp_mux_select_gpio_pin_free = true;
+			gpio_export(sciaps_micro->dpp_mux_select_gpio_pin, false);
+		}
+
+		rc = gpio_request(sciaps_micro->dpp_mux_select_legacy_gpio_pin, dpp_mux_select_legacy_dt_name);
+		if (rc) {
+			dev_err(&client->dev, "%s: gpio %d(%s) request failed with err: %d\n",
+					__func__, sciaps_micro->dpp_mux_select_legacy_gpio_pin, dpp_mux_select_legacy_dt_name,  rc);
+		}
+		else {
+			sciaps_micro->dpp_mux_select_legacy_gpio_pin_free = true;
+			gpio_export(sciaps_micro->dpp_mux_select_legacy_gpio_pin, false);
+		}
+
+		{
+			int dpp_mux_select_value, dpp_mux_select_legacy_value;
+
+			dev_info(&client->dev, "%s: Verifing HW Rev of the carrier board (GPIO_%d vs GPIO_%d)...\n", __func__, sciaps_micro->dpp_mux_select_gpio_pin, sciaps_micro->dpp_mux_select_legacy_gpio_pin);
+			gpio_direction_input(sciaps_micro->dpp_mux_select_gpio_pin);
+			gpio_direction_input(sciaps_micro->dpp_mux_select_legacy_gpio_pin);
+
+			dpp_mux_select_value = gpio_get_value(sciaps_micro->dpp_mux_select_gpio_pin);
+			dpp_mux_select_legacy_value = gpio_get_value(sciaps_micro->dpp_mux_select_legacy_gpio_pin);
+
+			dev_info(&client->dev, "%s: %s is %d and %s is %d\n",
+					__func__, dpp_mux_select_dt_name, dpp_mux_select_value, dpp_mux_select_legacy_dt_name, dpp_mux_select_legacy_value);
+
+			if (dpp_mux_select_value == 1 && dpp_mux_select_legacy_value == 0) {
+				sciaps_micro->carrier_board_hw_rev = SCIAPS_CARRIER_BOARD_HW_REV_10_PLUS_BLUE;
+			}
+			else if (dpp_mux_select_value == 0 && dpp_mux_select_legacy_value == 1) {
+				sciaps_micro->carrier_board_hw_rev = SCIAPS_CARRIER_BOARD_HW_REV_PRIOR_REV_10_RED;
+#if SCIAPS_DPP_MUX_SELECT_WORK
+				schedule_delayed_work(&sciaps_micro->work, 1*HZ);
+#endif
+			}
+			else {
+				sciaps_micro->carrier_board_hw_rev = SCIAPS_CARRIER_BOARD_HW_REV_UNKNOWN;
+			}
+		}
+
+		dev_info(&client->dev, "%s: HW Rev of the carrier board is %d\n", __func__, sciaps_micro->carrier_board_hw_rev);
+
+		dev_info(&client->dev, "%s: Setting %s as output to %d\n", __func__, dpp_mux_select_dt_name, sciaps_micro->dpp_mux_select_gpio_pin_value);
+		gpio_direction_output(sciaps_micro->dpp_mux_select_gpio_pin, sciaps_micro->dpp_mux_select_gpio_pin_value);
+		gpio_set_value(sciaps_micro->dpp_mux_select_gpio_pin, sciaps_micro->dpp_mux_select_gpio_pin_value);
+
+		dev_info(&client->dev, "%s: Setting %s as output to %d\n", __func__, dpp_mux_select_legacy_dt_name, sciaps_micro->dpp_mux_select_gpio_pin_value);
+		gpio_direction_output(sciaps_micro->dpp_mux_select_legacy_gpio_pin, sciaps_micro->dpp_mux_select_gpio_pin_value);
+		gpio_set_value(sciaps_micro->dpp_mux_select_legacy_gpio_pin, sciaps_micro->dpp_mux_select_gpio_pin_value);
+
+	}
+
 	dev_info(&client->dev, "device probed\n");
 
 	return 0;
@@ -562,6 +806,18 @@ static int sciaps_micro_remove(struct i2c_client *client)
 	sciaps_micro_delete_sysfs(client);
 
 	trigger_gpio_clean(client, SCIAPS_TRIGGER_GPIO_CLEAN_ALL);
+
+	if (sciaps_micro->dpp_mux_select_gpio_pin_free && sciaps_micro->dpp_mux_select_gpio_pin != -1) {
+		gpio_free(sciaps_micro->dpp_mux_select_gpio_pin);
+	}
+	sciaps_micro->dpp_mux_select_gpio_pin = -1;
+	sciaps_micro->dpp_mux_select_gpio_pin_free = false;
+
+	if (sciaps_micro->dpp_mux_select_legacy_gpio_pin_free && sciaps_micro->dpp_mux_select_legacy_gpio_pin != -1) {
+		gpio_free(sciaps_micro->dpp_mux_select_legacy_gpio_pin);
+	}
+	sciaps_micro->dpp_mux_select_legacy_gpio_pin = -1;
+	sciaps_micro->dpp_mux_select_legacy_gpio_pin_free = false;
 
 	i2c_unregister_device(client);
 

--- a/drivers/sciaps/ublox-sam-m10q-i2c.c
+++ b/drivers/sciaps/ublox-sam-m10q-i2c.c
@@ -641,7 +641,7 @@ static uint8_t s_default_config_status;
 
 static void dev_info_data(struct ublox_sam_m10q_info_t* chip, char* prefix, uint8_t* data, uint16_t data_len)
 {
-	static char str[16*3], str_byte[10];
+	static char str[16*3 + 1], str_byte[10];
 	int i;
 
 	str[0] = 0;
@@ -662,7 +662,7 @@ static void dev_info_data(struct ublox_sam_m10q_info_t* chip, char* prefix, uint
 
 static void dev_dbg_data(struct ublox_sam_m10q_info_t* chip, char* prefix, uint8_t* data, uint16_t data_len)
 {
-	static char str[16*3], str_byte[10];
+	static char str[16*3 + 1], str_byte[10];
 	int i;
 
 	str[0] = 0;


### PR DESCRIPTION

BTX:
- Auto-focus changed to  Macro Camera
- BTX specific device tree added. Board Hardware Id: 32

NGX:
- DPP mux select pin 96 and pin 108 initialization and setting them both as output high early in boot process during sciaps_micro driver probing. 
- Automatic board revision detection for logging purposes only.

U-Blox GNSS driver minor bug fix.